### PR TITLE
Migrate Pivotal tasks to Trello tasks checklists.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -224,7 +224,7 @@ Click the *Allow* button, and you will be presented with a 64-character token.
 
 See the [Trello documentation](https://trello.com/docs/gettingstarted/index.html#getting-an-application-key) for more details.
 
-The Pivotal Tracker token can be found at the bottom of your [Pivotal profile page](https://www.pivotaltracker.com/profile).
+The Pivotal Tracker token can be found at the bottom of your [Pivotal profile page](https://www.pivotaltracker.com/profile).  Make sure that "Require HTTPS for API Access" is OFF!
 
 Change history
 --------------

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ Jeweler::Tasks.new do |gem|
   gem.summary     = %Q{Pivotal Tracker to Trello exporter}
   gem.description = %Q{Pulls stories from Pivotal Tracker and imports them into Trello}
   gem.email       = "hello@daveperrett.com"
-  gem.authors     = ["Dave Perrett"]
+  gem.authors     = ["Dave Perrett", "Erik Frederiksen"]
   # dependencies defined in Gemfile
 end
 Jeweler::RubygemsDotOrgTasks.new

--- a/lib/pivotal_to_trello/trello_wrapper.rb
+++ b/lib/pivotal_to_trello/trello_wrapper.rb
@@ -27,6 +27,19 @@ module PivotalToTrello
           card.add_comment("[#{note.author}] #{note.text.to_s.strip}") unless note.text.to_s.strip.empty?
         end
 
+        tasks = pivotal_story.tasks.all
+        if !tasks.empty?
+          checklist = Trello::Checklist.create( 
+            :name     => 'Tasks',
+            :board_id => card.board_id
+          )
+          card.add_checklist(checklist)
+          tasks.each do |task|
+            puts " Creating task '#{task.description}'"
+            checklist.add_item(task.description, task.complete)
+          end
+        end
+
         card
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ def mock_pivotal_story(options = {})
   }.merge(options)
   story = double(PivotalTracker::Story)
   story.stub_chain(:notes, :all).and_return([])
+  story.stub_chain(:tasks, :all).and_return([])
   options.each { |k, v| story.stub(k => v) }
   story
 end
@@ -42,6 +43,7 @@ def mock_trello_card(options = {})
   options = {
     :name => 'My Card',
     :desc => 'My Description',
+    :board_id => 1234321,
   }.merge(options)
   card = double(Trello::Card)
   options.each { |k, v| card.stub(k => v) }


### PR DESCRIPTION
Hey there.  Here's a patch that uploads tasks from Pivotal stories to Trello cards and marks them completed / checked if it's appropriate.
