### PR TITLE
Pivotal Tracker API requires SSL enabled

### DIFF
--- a/lib/pivotal_to_trello/pivotal_wrapper.rb
+++ b/lib/pivotal_to_trello/pivotal_wrapper.rb
@@ -7,6 +7,7 @@ module PivotalToTrello
     # Constructor
     def initialize(token)
       ::PivotalTracker::Client.token = token
+      ::PivotalTracker::Client.use_ssl = true
     end
 
     # Returns a hash of available projects keyed on project ID.


### PR DESCRIPTION
Otherwise, returns 400 Bad Request, see https://github.com/recurser/pivotal-to-trello/issues/2

I couldn't run the specs, but real-world-wise, it works now, and it didn't before :smile: 

Thanks again for the gem (I think the other PR can be merged as well)
